### PR TITLE
Fix deprecated Author config for authorbox

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -6,11 +6,6 @@ theme = "mainroad"
 disqusShortname = "" # Enable comments by entering your Disqus shortname
 googleAnalytics = "" # Enable Google Analytics by entering your tracking id
 
-[Author]
-  name = "John Doe"
-  bio = "John Doe's true identity is unknown. Maybe he is a successful blogger or writer. Nobody knows it."
-  avatar = "img/avatar.png"
-
 [Params]
   description = "John Doe's Personal blog about everything" # Description of your site
   opengraph = true
@@ -20,6 +15,11 @@ googleAnalytics = "" # Enable Google Analytics by entering your tracking id
   pager = true
   post_meta = ["date", "categories"] # Order of post meta information
   mainSections = ["post", "docs"]
+
+[Params.Author]
+  name = "John Doe"
+  bio = "John Doe's true identity is unknown. Maybe he is a successful blogger or writer. Nobody knows it."
+  avatar = "img/avatar.png"
 
 [Params.logo]
   subtitle = "Just another site" # Logo subtitle

--- a/layouts/partials/authorbox.html
+++ b/layouts/partials/authorbox.html
@@ -1,21 +1,21 @@
 {{- if .Param "authorbox" }}
 <div class="authorbox clearfix">
-	{{- if and (not .Site.Author.avatar) (not .Site.Author.name) (not .Site.Author.bio) }}
+	{{- if and (not .Site.Params.Author.avatar) (not .Site.Params.Author.name) (not .Site.Author.bio) }}
 	<p class="authorbox__warning">
-		<strong>WARNING:</strong> Authorbox is activated, but [Author] parameters are not specified.
+		<strong>WARNING:</strong> Authorbox is activated, but [Params.Author] parameters are not specified.
 	</p>
 	{{- end }}
-	{{- with .Site.Author.avatar }}
+	{{- with .Site.Params.Author.avatar }}
 	<figure class="authorbox__avatar">
-		<img alt="{{ $.Site.Author.name }} avatar" src="{{ $.Site.Author.avatar | relURL }}" class="avatar" height="90" width="90">
+		<img alt="{{ $.Site.Params.Author.name }} avatar" src="{{ $.Site.Params.Author.avatar | relURL }}" class="avatar" height="90" width="90">
 	</figure>
 	{{- end }}
-	{{- with .Site.Author.name }}
+	{{- with .Site.Params.Author.name }}
 	<div class="authorbox__header">
 		<span class="authorbox__name">{{ T "authorbox_name" (dict "Name" .) }}</span>
 	</div>
 	{{- end }}
-	{{- with .Site.Author.bio }}
+	{{- with .Site.Params.Author.bio }}
 	<div class="authorbox__description">
 		{{ . | markdownify }}
 	</div>

--- a/layouts/partials/post_meta/author.html
+++ b/layouts/partials/post_meta/author.html
@@ -1,6 +1,6 @@
-{{- if .Site.Author.name -}}
+{{- if .Site.Params.Author.name -}}
 <div class="meta__item-author meta__item">
 	{{ partial "svg/author.svg" (dict "class" "meta__icon") -}}
-	<span class="meta__text">{{ .Site.Author.name }}</span>
+	<span class="meta__text">{{ .Site.Params.Author.name }}</span>
 </div>
 {{- end -}}


### PR DESCRIPTION
```
INFO  deprecated: .Site.Author was deprecated in Hugo v0.124.0 
and will be removed in a future release.
Use taxonomies instead.
```

This PR fixes the template replacing the references to `Author` by the new supported form.